### PR TITLE
Object data type & module

### DIFF
--- a/builtins/print.go
+++ b/builtins/print.go
@@ -24,8 +24,14 @@ func print(args []lang.Type, opt *lang.Options) lang.Type {
 			outtxt += "]"
 		} else if v, ok := t.Val().(*object.Object); ok {
 			outtxt += "{"
+			i := 0
 			for k, t2 := range v.Value {
+
 				outtxt += fmt.Sprint(k+": ") + fmt.Sprint(t2.Val())
+				if i != len(v.Value)-1 {
+					outtxt += ", "
+				}
+				i += 1
 			}
 			outtxt += "}"
 		} else {

--- a/builtins/print.go
+++ b/builtins/print.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/glaukiol1/gago/lang"
 	"github.com/glaukiol1/gago/stdlib/array"
+	"github.com/glaukiol1/gago/stdlib/object"
 )
 
 // the print() function
@@ -21,6 +22,13 @@ func print(args []lang.Type, opt *lang.Options) lang.Type {
 				}
 			}
 			outtxt += "]"
+		}
+		if v, ok := t.Val().(*object.Object); ok {
+			outtxt += "{"
+			for k, t2 := range v.Value {
+				outtxt += fmt.Sprint(k+": ") + fmt.Sprint(t2.Val())
+			}
+			outtxt += "}"
 		} else {
 			outtxt += fmt.Sprint(t.Val())
 		}

--- a/builtins/print.go
+++ b/builtins/print.go
@@ -22,8 +22,7 @@ func print(args []lang.Type, opt *lang.Options) lang.Type {
 				}
 			}
 			outtxt += "]"
-		}
-		if v, ok := t.Val().(*object.Object); ok {
+		} else if v, ok := t.Val().(*object.Object); ok {
 			outtxt += "{"
 			for k, t2 := range v.Value {
 				outtxt += fmt.Sprint(k+": ") + fmt.Sprint(t2.Val())

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -6,6 +6,7 @@ This file contains the basic syntax info. For other docs:
 
 - [Data types](datatypes.md)
 - [Array Module](array.md)
+- [Object Module](object.md)
 
 ## Basic Syntax
 

--- a/docs/object.md
+++ b/docs/object.md
@@ -1,0 +1,38 @@
+# Object | Standard Library Module
+
+The object module has functions for interacting with objects in Gago.
+
+## Creating A Object
+
+To create a new object, you run the `object.create()` function. It has no paramaters and returns a blank object.
+
+## Setting a value
+
+To set a value of a object in Gago, you use the `object.set()` function. The syntax is as follows:
+
+```js
+object.set(obj, key, value)
+```
+
+- `obj` object
+- `key` the key that will hold the value (string)
+- `value` any value you would like to assign to that key
+
+This function returns a `object` type.
+
+## Getting a value
+
+To get a value, you use the `object.get()` function. The syntax is as follows:
+
+```js
+object.get(obj, key)
+```
+
+- `obj` object
+- `key` the key that you want to get the value of
+
+This returns the value of that key-value pair or `null`.
+
+## Getting all keys
+
+To get a array of all the keys, you use the `object.keys()` function. Its only paramater is the object. It returns a [object](object.md) which contains strings (keys).

--- a/examples/object.gago
+++ b/examples/object.gago
@@ -6,10 +6,10 @@ call object.set(obj, "test", 1234)
 
 call print("obj:", obj)
 
-const val = call object.get(obj, "test")
-
-call print("test value:", val)
-
 const keys = call object.keys(obj)
 
 call print("keys:", keys)
+
+const val = call object.get(obj, "test")
+
+call print('"test" value:', val)

--- a/examples/object.gago
+++ b/examples/object.gago
@@ -2,4 +2,10 @@ import object
 
 const obj = call object.create()
 
+call object.set(obj, "test", 1234)
+
 call print(obj)
+
+const val = call object.get(obj, "test")
+
+call print(val)

--- a/examples/object.gago
+++ b/examples/object.gago
@@ -4,8 +4,12 @@ const obj = call object.create()
 
 call object.set(obj, "test", 1234)
 
-call print(obj)
+call print("obj:", obj)
 
 const val = call object.get(obj, "test")
 
-call print(val)
+call print("test value:", val)
+
+const keys = call object.keys(obj)
+
+call print("keys:", keys)

--- a/stdlib/array/helpers.go
+++ b/stdlib/array/helpers.go
@@ -97,6 +97,8 @@ func subsliceArray(args []lang.Type, opt *lang.Options) lang.Type {
 				newV := new(Slice)
 				newV.Items = v.Items[i1:i2]
 				return lang.LoadCustomType("slice", newV)
+			} else {
+				lang.Errorf("TypeError", "Expected argument of type int (pos 3), but got "+args[2].Name(), "", true).Run()
 			}
 		} else {
 			lang.Errorf("TypeError", "Expected argument of type int (pos 2), but got "+args[1].Name(), "", true).Run()

--- a/stdlib/object/helpers.go
+++ b/stdlib/object/helpers.go
@@ -7,7 +7,7 @@ import (
 // functions for interacting with objects
 // in Gago
 
-// init a empty object
+// set a value in the given object.
 func setObject(args []lang.Type, opt *lang.Options) lang.Type {
 	if len(args) != 3 {
 		lang.Errorf("TypeError", "Expected 3 arguments", "\n\t At call for object.set", true).Run()
@@ -25,4 +25,4 @@ func setObject(args []lang.Type, opt *lang.Options) lang.Type {
 	return lang.Null
 }
 
-var FSet = lang.NewMethod("set", setObject, "init a empty object")
+var FSet = lang.NewMethod("set", setObject, "set a value in the given object.")

--- a/stdlib/object/helpers.go
+++ b/stdlib/object/helpers.go
@@ -33,7 +33,11 @@ func getObject(args []lang.Type, opt *lang.Options) lang.Type {
 	}
 	if v, ok := args[0].Val().(*Object); ok {
 		if i1, ok := args[1].Val().(string); ok {
-			return v.Value[i1]
+			if v.Value[i1] != nil {
+				return v.Value[i1]
+			} else {
+				return lang.Null
+			}
 		} else {
 			lang.Errorf("TypeError", "Expected argument of type string (pos 2), but got "+args[1].Name(), "", true).Run()
 		}

--- a/stdlib/object/helpers.go
+++ b/stdlib/object/helpers.go
@@ -25,4 +25,22 @@ func setObject(args []lang.Type, opt *lang.Options) lang.Type {
 	return lang.Null
 }
 
+// get a value in the given object.
+func getObject(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) != 2 {
+		lang.Errorf("TypeError", "Expected 2 arguments", "\n\t At call for object.get", true).Run()
+	}
+	if v, ok := args[0].Val().(*Object); ok {
+		if i1, ok := args[1].Val().(string); ok {
+			return v.Value[i1]
+		} else {
+			lang.Errorf("TypeError", "Expected argument of type string (pos 2), but got "+args[1].Name(), "", true).Run()
+		}
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type object (pos 1), but got "+args[0].Name(), "", true).Run()
+	}
+	return lang.Null
+}
+
 var FSet = lang.NewMethod("set", setObject, "set a value in the given object.")
+var FGet = lang.NewMethod("get", getObject, "get a value in the given object.")

--- a/stdlib/object/helpers.go
+++ b/stdlib/object/helpers.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"github.com/glaukiol1/gago/lang"
+	"github.com/glaukiol1/gago/stdlib/array"
 )
 
 // functions for interacting with objects
@@ -42,5 +43,23 @@ func getObject(args []lang.Type, opt *lang.Options) lang.Type {
 	return lang.Null
 }
 
+// get a slice of all keys in the object
+func keysObject(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) != 1 {
+		lang.Errorf("TypeError", "Expected 1 argument", "\n\t At call for object.keys", true).Run()
+	}
+	if v, ok := args[0].Val().(*Object); ok {
+		keys := make([]lang.Type, 0, len(v.Value))
+		for k := range v.Value {
+			keys = append(keys, lang.String(k))
+		}
+		return lang.LoadCustomType("slice", &array.Slice{Items: keys})
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type object (pos 1), but got "+args[0].Name(), "", true).Run()
+	}
+	return lang.Null
+}
+
 var FSet = lang.NewMethod("set", setObject, "set a value in the given object.")
 var FGet = lang.NewMethod("get", getObject, "get a value in the given object.")
+var FKeys = lang.NewMethod("keys", keysObject, "get a slice of all keys in the object.")

--- a/stdlib/object/helpers.go
+++ b/stdlib/object/helpers.go
@@ -1,0 +1,28 @@
+package object
+
+import (
+	"github.com/glaukiol1/gago/lang"
+)
+
+// functions for interacting with objects
+// in Gago
+
+// init a empty object
+func setObject(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) != 3 {
+		lang.Errorf("TypeError", "Expected 3 arguments", "\n\t At call for object.set", true).Run()
+	}
+	if v, ok := args[0].Val().(*Object); ok {
+		if i1, ok := args[1].Val().(string); ok {
+			v.Value[i1] = args[2]
+			return lang.Null
+		} else {
+			lang.Errorf("TypeError", "Expected argument of type string (pos 2), but got "+args[1].Name(), "", true).Run()
+		}
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type object (pos 1), but got "+args[0].Name(), "", true).Run()
+	}
+	return lang.Null
+}
+
+var FSet = lang.NewMethod("set", setObject, "init a empty object")

--- a/stdlib/object/object.go
+++ b/stdlib/object/object.go
@@ -13,6 +13,6 @@ func Init() *module.Module {
 	globals := make(map[string]lang.Type)
 
 	methods["create"] = FCreate
-
+	methods["set"] = FSet
 	return module.NewModule("object", methods, globals)
 }

--- a/stdlib/object/object.go
+++ b/stdlib/object/object.go
@@ -14,5 +14,6 @@ func Init() *module.Module {
 
 	methods["create"] = FCreate
 	methods["set"] = FSet
+	methods["get"] = FGet
 	return module.NewModule("object", methods, globals)
 }

--- a/stdlib/object/object.go
+++ b/stdlib/object/object.go
@@ -15,5 +15,6 @@ func Init() *module.Module {
 	methods["create"] = FCreate
 	methods["set"] = FSet
 	methods["get"] = FGet
+	methods["keys"] = FKeys
 	return module.NewModule("object", methods, globals)
 }

--- a/stdlib/object/object_test.go
+++ b/stdlib/object/object_test.go
@@ -1,0 +1,61 @@
+package object_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/glaukiol1/gago/run"
+)
+
+func TestObject(t *testing.T) {
+	out1 := captureOutput(func() {
+		run.RunData("import object\nconst a = call object.create()\ncall print(a)", "<test>", false)
+	})
+	if strings.TrimSpace(out1) != "{}" {
+		t.Errorf("Expected %s found %s", "{}", out1)
+	}
+	out2 := captureOutput(func() {
+		run.RunData("import object\nconst a = call object.create()\ncall object.set(a, 'test', 1)\ncall print(a)", "<test>", false)
+	})
+	if strings.TrimSpace(out2) != "{test: 1}" {
+		t.Errorf("Expected %s found %s", "{test: 1}", out2)
+	}
+	out3 := captureOutput(func() {
+		run.RunData("import object\nconst a = call object.create()\ncall object.set(a, 'test', 1)\nconst b = call object.get(a, 'test')\ncall print(b)", "<test>", false)
+	})
+	if strings.TrimSpace(out3) != "1" {
+		t.Errorf("Expected %s found %s", "1", out3)
+	}
+	out4 := captureOutput(func() {
+		run.RunData("import object\nconst a = call object.create()\ncall object.set(a, 'test', 1)\ncall object.set(a, 'test1', 1)\ncall print(call object.keys(a))", "<test>", false)
+	})
+	if strings.TrimSpace(out4) != "[test, test1]" {
+		t.Errorf("Expected %s found %s", "[test, test1]", out4)
+	}
+}
+
+func captureOutput(s func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	s()
+
+	outC := make(chan string)
+
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// back to normal state
+	w.Close()
+	os.Stdout = old
+	out := <-outC
+
+	return out
+}


### PR DESCRIPTION
Create the object data type and standard library module.

- [x] Create the basic `object` type
- [x] Format for printing
- [x] Add a `set` method
- [x] Add a `get` method
- [x] Add a `keys` method (returns a `slice`)
- [x] Add docs for object
- [x] Add tests for object

Fixes #4 