### PR TITLE
Add String Module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ example10:
 	make build
 	echo "\n\n\n\033[95mrunning object example...\033[0m"
 	./gago run --file examples/object.gago
+example11:
+	make build
+	echo "\n\n\n\033[95mrunning string example...\033[0m"
+	./gago run --file examples/string.gago
 xrepl:
 	make build
 	./gago

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -14,6 +14,10 @@ The basic syntax for the Gago language.
 
 The Gago programming language is based off of lines, not semicolons (`;`), so expressions must be of one line, except some special expressions: such as `for` `if` ...
 
+### Importing modules
+
+To import a module, you enter the `import` keyword followed by the name of the module. To import the string module for example, you would do: `import string`. Now all the `string` methods and globals are accessible via `string.<field>`.
+
 ### Defining Variables
 
 Defining a variable will add it to the memory map, which can be accessed or manipulated later on.

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -7,6 +7,7 @@ This file contains the basic syntax info. For other docs:
 - [Data types](datatypes.md)
 - [Array Module](array.md)
 - [Object Module](object.md)
+- [String Module](string.md)
 
 ## Basic Syntax
 

--- a/docs/string.md
+++ b/docs/string.md
@@ -1,0 +1,19 @@
+# String | Standard Library Module
+
+The string module contains functions for interacting with strings in Gago.
+
+A string is a base data type, so you can create it directly, with no need for a function. Example: `const a = "hello!"`.
+
+## Functions
+
+- concat(str, args...) `concat joins all the arguments together`
+- contains(str, substr) `contains searches for the substring in the specified string. Returns a boolean`
+- containsAny(str, chars) `containsAny checks if any of the chars are in the set string. Returns a boolean`
+- trimSpace(str) `trimSpace removes all trailing and leading whitespaces and returns the new string`
+- index(str, substr) `index returns the index of the first instance of substr in string, or -1 if substr is not present in string.`
+- len(str) `len returns the length of the string`
+- charAt(str, index) `charAt returns the character at the given index, or a IndexError`
+
+## Importing
+
+To import the string module, since its part of the standard library, you can import it by default: `import string`.

--- a/examples/string.gago
+++ b/examples/string.gago
@@ -11,3 +11,8 @@ call print("string contains 'hello':", contains1)
 const containsany1 = call string.containsAny(str, "xyz")
 
 call print("string containsAny 'xyz':", containsany1)
+
+const trimedSpace = call string.trimSpace("  1234  ")
+
+const s = call string.concat("trimSpace '  1234  ' = |", trimedSpace, "|")
+call print(s)

--- a/examples/string.gago
+++ b/examples/string.gago
@@ -12,6 +12,10 @@ const containsany1 = call string.containsAny(str, "xyz")
 
 call print("string containsAny 'xyz':", containsany1)
 
+const indx1 = call string.index(str, "world")
+
+call print("string index 'world':", indx1)
+
 const trimedSpace = call string.trimSpace("  1234  ")
 
 const s = call string.concat("trimSpace '  1234  ' = |", trimedSpace, "|")

--- a/examples/string.gago
+++ b/examples/string.gago
@@ -17,6 +17,10 @@ const indx1 = call string.index(str, "world")
 call print("string index 'world':", indx1)
 call print("len of string:", call string.len(str))
 
+const atidx2 = call string.charAt(str, 2)
+
+call print("at index 2:", atidx2)
+
 const trimedSpace = call string.trimSpace("  1234  ")
 
 const s = call string.concat("trimSpace '  1234  ' = |", trimedSpace, "|")

--- a/examples/string.gago
+++ b/examples/string.gago
@@ -1,0 +1,5 @@
+import string
+
+const str = call string.concat("hello", " ", "world", "!")
+
+call print(str)

--- a/examples/string.gago
+++ b/examples/string.gago
@@ -15,6 +15,7 @@ call print("string containsAny 'xyz':", containsany1)
 const indx1 = call string.index(str, "world")
 
 call print("string index 'world':", indx1)
+call print("len of string:", call string.len(str))
 
 const trimedSpace = call string.trimSpace("  1234  ")
 

--- a/examples/string.gago
+++ b/examples/string.gago
@@ -3,3 +3,7 @@ import string
 const str = call string.concat("hello", " ", "world", "!")
 
 call print(str)
+
+const contains1 = call string.contains(str, "hello")
+
+call print("string contains 'hello':", contains1)

--- a/examples/string.gago
+++ b/examples/string.gago
@@ -7,3 +7,7 @@ call print(str)
 const contains1 = call string.contains(str, "hello")
 
 call print("string contains 'hello':", contains1)
+
+const containsany1 = call string.containsAny(str, "xyz")
+
+call print("string containsAny 'xyz':", containsany1)

--- a/lang/errors.go
+++ b/lang/errors.go
@@ -28,7 +28,7 @@ func (baseError *BaseError) Run() {
 	if baseError.IsFatal {
 		fmt.Print(baseError.Type + ": " + baseError.Message)
 		fmt.Println(baseError.stack)
-		os.Exit(0)
+		os.Exit(1)
 	}
 	fmt.Print(baseError.Type + ": " + baseError.Message)
 	fmt.Println(baseError.stack)

--- a/lang/errors.go
+++ b/lang/errors.go
@@ -8,7 +8,7 @@ import (
 type BaseError struct {
 	Type    string
 	Message string
-	stack   string
+	Stack   string
 	IsFatal bool
 }
 
@@ -27,13 +27,13 @@ func (baseError *BaseError) Error() string {
 func (baseError *BaseError) Run() {
 	if baseError.IsFatal {
 		fmt.Print(baseError.Type + ": " + baseError.Message)
-		fmt.Println(baseError.stack)
+		fmt.Println(baseError.Stack)
 		os.Exit(1)
 	}
 	fmt.Print(baseError.Type + ": " + baseError.Message)
-	fmt.Println(baseError.stack)
+	fmt.Println(baseError.Stack)
 }
 
-func Errorf(errtype, message, stack string, isFatal bool) *BaseError {
-	return &BaseError{errtype, message, stack, isFatal}
+func Errorf(errtype, message, Stack string, isFatal bool) *BaseError {
+	return &BaseError{errtype, message, Stack, isFatal}
 }

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -10,6 +10,7 @@ import (
 	"github.com/glaukiol1/gago/module"
 	array "github.com/glaukiol1/gago/stdlib/array"
 	object "github.com/glaukiol1/gago/stdlib/object"
+	string "github.com/glaukiol1/gago/stdlib/string"
 	mod "github.com/glaukiol1/gago/stdlib/test"
 )
 
@@ -18,5 +19,6 @@ func Modules() []*module.Module {
 	r = append(r, mod.Init())
 	r = append(r, array.Init())
 	r = append(r, object.Init())
+	r = append(r, string.Init())
 	return r
 }

--- a/stdlib/string/helpers.go
+++ b/stdlib/string/helpers.go
@@ -65,14 +65,14 @@ func containsAnyString(args []lang.Type, opt *lang.Options) lang.Type {
 	if x.Name() == "string" {
 		str += x.Val().(string)
 	} else {
-		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.contains", true).Run()
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.containsAny", true).Run()
 	}
 
 	x = args[1]
 	if x.Name() == "string" {
 		searchstr += x.Val().(string)
 	} else {
-		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.contains", true).Run()
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.containsAny", true).Run()
 	}
 	res := strings.ContainsAny(str, searchstr)
 	if res == true {
@@ -81,6 +81,23 @@ func containsAnyString(args []lang.Type, opt *lang.Options) lang.Type {
 	return lang.False
 }
 
+// trimSpace removes all trailing and leading whitespaces
+// and returns the new string
+func trimSpaceString(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) != 1 {
+		lang.Errorf("TypeError", "Expected 2 arguments", "\n\t At call for string.trimSpace", true).Run()
+	}
+	str := ""
+	x := args[0]
+	if x.Name() == "string" {
+		str += x.Val().(string)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.trimSpace", true).Run()
+	}
+	return lang.String(strings.TrimSpace(str))
+}
+
 var FConcat = lang.NewMethod("concat", concatString, "concat joins all the arguments together")
 var FContains = lang.NewMethod("contains", containsString, "contains searches for the substring in the specified string. Returns a boolean")
-var FContainsAny = lang.NewMethod("containsAny", containsAnyString, "ccontainsAny checks if any of the chars are in the set string. Returns a boolean")
+var FContainsAny = lang.NewMethod("containsAny", containsAnyString, "containsAny checks if any of the chars are in the set string. Returns a boolean")
+var FTrimSpace = lang.NewMethod("trimSpace", trimSpaceString, "trimSpace removes all trailing and leading whitespaces and returns the new string")

--- a/stdlib/string/helpers.go
+++ b/stdlib/string/helpers.go
@@ -122,8 +122,24 @@ func indexString(args []lang.Type, opt *lang.Options) lang.Type {
 	return lang.Int(int64(res))
 }
 
+// len returns the length of the string
+func lenString(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) != 1 {
+		lang.Errorf("TypeError", "Expected 1 argument", "\n\t At call for string.trimSpace", true).Run()
+	}
+	str := ""
+	x := args[0]
+	if x.Name() == "string" {
+		str += x.Val().(string)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.trimSpace", true).Run()
+	}
+	return lang.Int(int64(len(str)))
+}
+
 var FConcat = lang.NewMethod("concat", concatString, "concat joins all the arguments together")
 var FContains = lang.NewMethod("contains", containsString, "contains searches for the substring in the specified string. Returns a boolean")
 var FContainsAny = lang.NewMethod("containsAny", containsAnyString, "containsAny checks if any of the chars are in the set string. Returns a boolean")
 var FTrimSpace = lang.NewMethod("trimSpace", trimSpaceString, "trimSpace removes all trailing and leading whitespaces and returns the new string")
 var FIndex = lang.NewMethod("index", indexString, "index returns the index of the first instance of substr in string, or -1 if substr is not present in string.")
+var FLen = lang.NewMethod("len", lenString, "len returns the length of the string")

--- a/stdlib/string/helpers.go
+++ b/stdlib/string/helpers.go
@@ -1,0 +1,4 @@
+package string
+
+// this file contains helper functions
+// for interacting with strings

--- a/stdlib/string/helpers.go
+++ b/stdlib/string/helpers.go
@@ -1,6 +1,10 @@
 package string
 
-import "github.com/glaukiol1/gago/lang"
+import (
+	"strings"
+
+	"github.com/glaukiol1/gago/lang"
+)
 
 // this file contains helper functions
 // for interacting with strings
@@ -21,4 +25,33 @@ func concatString(args []lang.Type, opt *lang.Options) lang.Type {
 	return lang.String(result)
 }
 
+// contains searches for the substring in the specified
+// string. Returns a boolean
+func containsString(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) != 2 {
+		lang.Errorf("TypeError", "Expected 2 arguments", "\n\t At call for string.contains", true).Run()
+	}
+	str := ""
+	searchstr := ""
+	x := args[0]
+	if x.Name() == "string" {
+		str += x.Val().(string)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.contains", true).Run()
+	}
+
+	x = args[1]
+	if x.Name() == "string" {
+		searchstr += x.Val().(string)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.contains", true).Run()
+	}
+	res := strings.Contains(str, searchstr)
+	if res == true {
+		return lang.True
+	}
+	return lang.False
+}
+
 var FConcat = lang.NewMethod("concat", concatString, "concat joins all the arguments together")
+var FContains = lang.NewMethod("contains", containsString, "contains searches for the substring in the specified string. Returns a boolean")

--- a/stdlib/string/helpers.go
+++ b/stdlib/string/helpers.go
@@ -1,6 +1,7 @@
 package string
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/glaukiol1/gago/lang"
@@ -125,16 +126,43 @@ func indexString(args []lang.Type, opt *lang.Options) lang.Type {
 // len returns the length of the string
 func lenString(args []lang.Type, opt *lang.Options) lang.Type {
 	if len(args) != 1 {
-		lang.Errorf("TypeError", "Expected 1 argument", "\n\t At call for string.trimSpace", true).Run()
+		lang.Errorf("TypeError", "Expected 1 argument", "\n\t At call for string.len", true).Run()
 	}
 	str := ""
 	x := args[0]
 	if x.Name() == "string" {
 		str += x.Val().(string)
 	} else {
-		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.trimSpace", true).Run()
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.len", true).Run()
 	}
 	return lang.Int(int64(len(str)))
+}
+
+// charAt returns the character
+// at the given index, or a IndexError
+func charAtString(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) != 2 {
+		lang.Errorf("TypeError", "Expected 2 arguments", "\n\t At call for string.charAt", true).Run()
+	}
+	str := ""
+	var idx int64
+	x := args[0]
+	if x.Name() == "string" {
+		str += x.Val().(string)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.charAt", true).Run()
+	}
+
+	x = args[1]
+	if x.Name() == "int" {
+		idx = x.Val().(int64)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type int64", "\n\t At call for string.charAt", true).Run()
+	}
+	if idx > int64(len(str))-1 {
+		lang.Errorf("IndexError", "Index "+fmt.Sprint(idx)+" out of bounds", "\n\t At call for string.charAt", true).Run()
+	}
+	return lang.String(string(str[idx]))
 }
 
 var FConcat = lang.NewMethod("concat", concatString, "concat joins all the arguments together")
@@ -143,3 +171,4 @@ var FContainsAny = lang.NewMethod("containsAny", containsAnyString, "containsAny
 var FTrimSpace = lang.NewMethod("trimSpace", trimSpaceString, "trimSpace removes all trailing and leading whitespaces and returns the new string")
 var FIndex = lang.NewMethod("index", indexString, "index returns the index of the first instance of substr in string, or -1 if substr is not present in string.")
 var FLen = lang.NewMethod("len", lenString, "len returns the length of the string")
+var FCharAt = lang.NewMethod("charAt", charAtString, "charAt returns the character at the given index, or a IndexError")

--- a/stdlib/string/helpers.go
+++ b/stdlib/string/helpers.go
@@ -1,4 +1,24 @@
 package string
 
+import "github.com/glaukiol1/gago/lang"
+
 // this file contains helper functions
 // for interacting with strings
+
+// concat joins all the arguments together
+func concatString(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) < 2 {
+		lang.Errorf("TypeError", "Expected 2 or more arguments", "\n\t At call for string.concat", true).Run()
+	}
+	result := ""
+	for _, x := range args {
+		if x.Name() == "string" {
+			result += x.Val().(string)
+		} else {
+			lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.concat", true).Run()
+		}
+	}
+	return lang.String(result)
+}
+
+var FConcat = lang.NewMethod("concat", concatString, "concat joins all the arguments together")

--- a/stdlib/string/helpers.go
+++ b/stdlib/string/helpers.go
@@ -85,7 +85,7 @@ func containsAnyString(args []lang.Type, opt *lang.Options) lang.Type {
 // and returns the new string
 func trimSpaceString(args []lang.Type, opt *lang.Options) lang.Type {
 	if len(args) != 1 {
-		lang.Errorf("TypeError", "Expected 2 arguments", "\n\t At call for string.trimSpace", true).Run()
+		lang.Errorf("TypeError", "Expected 1 argument", "\n\t At call for string.trimSpace", true).Run()
 	}
 	str := ""
 	x := args[0]
@@ -97,7 +97,33 @@ func trimSpaceString(args []lang.Type, opt *lang.Options) lang.Type {
 	return lang.String(strings.TrimSpace(str))
 }
 
+// Index returns the index of the first instance of substr
+// in string, or -1 if substr is not present in string.
+func indexString(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) != 2 {
+		lang.Errorf("TypeError", "Expected 2 arguments", "\n\t At call for string.index", true).Run()
+	}
+	str := ""
+	searchstr := ""
+	x := args[0]
+	if x.Name() == "string" {
+		str += x.Val().(string)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.index", true).Run()
+	}
+
+	x = args[1]
+	if x.Name() == "string" {
+		searchstr += x.Val().(string)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.index", true).Run()
+	}
+	res := strings.Index(str, searchstr)
+	return lang.Int(int64(res))
+}
+
 var FConcat = lang.NewMethod("concat", concatString, "concat joins all the arguments together")
 var FContains = lang.NewMethod("contains", containsString, "contains searches for the substring in the specified string. Returns a boolean")
 var FContainsAny = lang.NewMethod("containsAny", containsAnyString, "containsAny checks if any of the chars are in the set string. Returns a boolean")
 var FTrimSpace = lang.NewMethod("trimSpace", trimSpaceString, "trimSpace removes all trailing and leading whitespaces and returns the new string")
+var FIndex = lang.NewMethod("index", indexString, "index returns the index of the first instance of substr in string, or -1 if substr is not present in string.")

--- a/stdlib/string/helpers.go
+++ b/stdlib/string/helpers.go
@@ -53,5 +53,34 @@ func containsString(args []lang.Type, opt *lang.Options) lang.Type {
 	return lang.False
 }
 
+// containsAny checks if any of the chars are in
+// the set string. Returns a boolean
+func containsAnyString(args []lang.Type, opt *lang.Options) lang.Type {
+	if len(args) != 2 {
+		lang.Errorf("TypeError", "Expected 2 arguments", "\n\t At call for string.contains", true).Run()
+	}
+	str := ""
+	searchstr := ""
+	x := args[0]
+	if x.Name() == "string" {
+		str += x.Val().(string)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.contains", true).Run()
+	}
+
+	x = args[1]
+	if x.Name() == "string" {
+		searchstr += x.Val().(string)
+	} else {
+		lang.Errorf("TypeError", "Expected argument of type string", "\n\t At call for string.contains", true).Run()
+	}
+	res := strings.ContainsAny(str, searchstr)
+	if res == true {
+		return lang.True
+	}
+	return lang.False
+}
+
 var FConcat = lang.NewMethod("concat", concatString, "concat joins all the arguments together")
 var FContains = lang.NewMethod("contains", containsString, "contains searches for the substring in the specified string. Returns a boolean")
+var FContainsAny = lang.NewMethod("containsAny", containsAnyString, "ccontainsAny checks if any of the chars are in the set string. Returns a boolean")

--- a/stdlib/string/string.go
+++ b/stdlib/string/string.go
@@ -13,6 +13,7 @@ func Init() *module.Module {
 	globals := make(map[string]lang.Type)
 
 	methods["concat"] = FConcat
+	methods["contains"] = FContains
 
 	return module.NewModule("string", methods, globals)
 }

--- a/stdlib/string/string.go
+++ b/stdlib/string/string.go
@@ -12,5 +12,7 @@ func Init() *module.Module {
 	methods := make(map[string]*lang.Method)
 	globals := make(map[string]lang.Type)
 
+	methods["concat"] = FConcat
+
 	return module.NewModule("string", methods, globals)
 }

--- a/stdlib/string/string.go
+++ b/stdlib/string/string.go
@@ -1,0 +1,16 @@
+package string
+
+import (
+	"github.com/glaukiol1/gago/lang"
+	"github.com/glaukiol1/gago/module"
+)
+
+// the string module is a standard library for
+// working with strings in Gago.
+
+func Init() *module.Module {
+	methods := make(map[string]*lang.Method)
+	globals := make(map[string]lang.Type)
+
+	return module.NewModule("string", methods, globals)
+}

--- a/stdlib/string/string.go
+++ b/stdlib/string/string.go
@@ -16,6 +16,7 @@ func Init() *module.Module {
 	methods["contains"] = FContains
 	methods["containsAny"] = FContainsAny
 	methods["trimSpace"] = FTrimSpace
+	methods["index"] = FIndex
 
 	return module.NewModule("string", methods, globals)
 }

--- a/stdlib/string/string.go
+++ b/stdlib/string/string.go
@@ -15,6 +15,7 @@ func Init() *module.Module {
 	methods["concat"] = FConcat
 	methods["contains"] = FContains
 	methods["containsAny"] = FContainsAny
+	methods["trimSpace"] = FTrimSpace
 
 	return module.NewModule("string", methods, globals)
 }

--- a/stdlib/string/string.go
+++ b/stdlib/string/string.go
@@ -14,6 +14,7 @@ func Init() *module.Module {
 
 	methods["concat"] = FConcat
 	methods["contains"] = FContains
+	methods["containsAny"] = FContainsAny
 
 	return module.NewModule("string", methods, globals)
 }

--- a/stdlib/string/string.go
+++ b/stdlib/string/string.go
@@ -17,6 +17,7 @@ func Init() *module.Module {
 	methods["containsAny"] = FContainsAny
 	methods["trimSpace"] = FTrimSpace
 	methods["index"] = FIndex
+	methods["len"] = FLen
 
 	return module.NewModule("string", methods, globals)
 }

--- a/stdlib/string/string.go
+++ b/stdlib/string/string.go
@@ -18,6 +18,7 @@ func Init() *module.Module {
 	methods["trimSpace"] = FTrimSpace
 	methods["index"] = FIndex
 	methods["len"] = FLen
+	methods["charAt"] = FCharAt
 
 	return module.NewModule("string", methods, globals)
 }

--- a/stdlib/string/string_test.go
+++ b/stdlib/string/string_test.go
@@ -1,0 +1,79 @@
+package string_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/glaukiol1/gago/run"
+)
+
+func TestString(t *testing.T) {
+	out1 := captureOutput(func() {
+		run.RunData("import string\nconst a = 'hello'\nconst b = 'world'\nconst c = call string.concat(a, ' ', b)\ncall print(c)", "<test>", false)
+	})
+	if strings.TrimSpace(out1) != "hello world" {
+		t.Errorf("Expected %s found %s", "hello world", out1)
+	}
+	out2 := captureOutput(func() {
+		run.RunData("import string\nconst a = 'hello world'\nconst b = call string.contains(a, 'world')\ncall print(b)", "<test>", false)
+	})
+	if strings.TrimSpace(out2) != "true" {
+		t.Errorf("Expected %s found %s", "true", out2)
+	}
+	out3 := captureOutput(func() {
+		run.RunData("import string\nconst a = 'hello world'\nconst b = call string.containsAny(a, 'o')\ncall print(b)", "<test>", false)
+	})
+	if strings.TrimSpace(out3) != "true" {
+		t.Errorf("Expected %s found %s", "true", out3)
+	}
+	out4 := captureOutput(func() {
+		run.RunData("import string\nconst a = '   hello world  '\nconst b = call string.trimSpace(a)\ncall print('|', b, '|')", "<test>", false)
+	})
+	if strings.TrimSpace(out4) != "| hello world |" {
+		t.Errorf("Expected %s found %s", "| hello world |", out4)
+	}
+	out5 := captureOutput(func() {
+		run.RunData("import string\nconst a = 'hello world'\nconst b = call string.index(a, 'h')\ncall print(b)", "<test>", false)
+	})
+	if strings.TrimSpace(out5) != "0" {
+		t.Errorf("Expected %s found %s", "0", out5)
+	}
+	out6 := captureOutput(func() {
+		run.RunData("import string\nconst a = 'hello world'\nconst b = call string.len(a)\ncall print(b)", "<test>", false)
+	})
+	if strings.TrimSpace(out6) != "11" {
+		t.Errorf("Expected %s found %s", "11", out6)
+	}
+	out7 := captureOutput(func() {
+		run.RunData("import string\nconst a = 'hello world'\nconst b = call string.charAt(a, 0)\ncall print(b)", "<test>", false)
+	})
+	if strings.TrimSpace(out7) != "h" {
+		t.Errorf("Expected %s found %s", "h", out7)
+	}
+}
+
+func captureOutput(s func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	s()
+
+	outC := make(chan string)
+
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// back to normal state
+	w.Close()
+	os.Stdout = old
+	out := <-outC
+
+	return out
+}


### PR DESCRIPTION
The `string` module will contain functions for interaction with strings in Gago.

Tasks:
- [x] Create a blank module
- [x] Functions
     - [x] concat
     - [x] contains
     - [x] containsAny
     - [x] trimSpace
     - [x] index
     - [x] len
     - [x] charAt
 - [x] Add docs
 - [ ] Add tests

Fixes #6 